### PR TITLE
Add pytest async support:

### DIFF
--- a/apps/gateway/signals.py
+++ b/apps/gateway/signals.py
@@ -1,3 +1,4 @@
+from asgiref.sync import async_to_sync
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
@@ -7,5 +8,5 @@ from .routing_state import update_uri_patterns_cache
 
 @receiver([post_save, post_delete], sender=URIPattern)
 @receiver([post_save, post_delete], sender=Upstream)
-async def refresh_patterns(sender, **kwargs):
-    await update_uri_patterns_cache()
+def refresh_patterns(sender, **kwargs):
+    async_to_sync(update_uri_patterns_cache)()

--- a/apps/gateway/tests.py
+++ b/apps/gateway/tests.py
@@ -14,24 +14,28 @@ ROUTES = [
         "methods": ("GET",),
         "requires_auth": True,
         "target_path": "",
+        "is_active": True,
     },
     {
         "pattern": "/api/v1/my-example/{id}/example_2",
         "methods": ("GET",),
         "requires_auth": True,
         "target_path": "",
+        "is_active": True,
     },
     {
         "pattern": "/api/v1/my-example/{id}/example_3",
         "methods": ("GET",),
         "requires_auth": True,
         "target_path": "",
+        "is_active": True,
     },
     {
         "pattern": "/api/v1/my-example/{id}/example4",
         "methods": ("GET",),
         "requires_auth": True,
         "target_path": "",
+        "is_active": True,
     },
 ]
 
@@ -84,11 +88,10 @@ def test_extract_token(test_input, expected_output):
 
 
 @pytest.mark.django_db
-def test_get_uri_patterns(uri_patterns: URIPattern):
-    assert get_uri_patterns()
+async def test_get_uri_patterns(uri_patterns: URIPattern):
+    assert await get_uri_patterns()
 
 
-@pytest.mark.asyncio
 @pytest.mark.django_db
 async def test_cache_refreshed_on_upstream_change():
     """Should refresh cache when an upstream is updated"""
@@ -100,16 +103,15 @@ async def test_cache_refreshed_on_upstream_change():
     )
 
     patterns = await get_uri_patterns()
-    assert patterns[0].upstream_base_url == "http://old-url.com/"
+    assert patterns[0].upstream_base_url == "http://old-url.com"
 
     upstream.base_url = "http://new-url.com"
     await sync_to_async(upstream.save)()
 
     patterns = await get_uri_patterns()
-    assert patterns[0].upstream_base_url == "http://new-url.com/"
+    assert patterns[0].upstream_base_url == "http://new-url.com"
 
 
-@pytest.mark.asyncio
 async def test_create_http_session_uses_env_proxy_settings():
     session = create_http_session()
     try:

--- a/poetry.lock
+++ b/poetry.lock
@@ -227,6 +227,19 @@ files = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+description = "Backport of asyncio.Runner, a context manager that controls event loop life cycle."
+optional = false
+python-versions = "<3.11,>=3.8"
+groups = ["dev"]
+markers = "python_version == \"3.10\""
+files = [
+    {file = "backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5"},
+    {file = "backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162"},
+]
+
+[[package]]
 name = "click"
 version = "8.3.1"
 description = "Composable command line interface toolkit"
@@ -1303,6 +1316,27 @@ tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+description = "Pytest support for asyncio"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5"},
+    {file = "pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5"},
+]
+
+[package.dependencies]
+backports-asyncio-runner = {version = ">=1.1,<2", markers = "python_version < \"3.11\""}
+pytest = ">=8.2,<10"
+typing-extensions = {version = ">=4.12", markers = "python_version < \"3.13\""}
+
+[package.extras]
+docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1)"]
+testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
+
+[[package]]
 name = "pytest-django"
 version = "4.12.0"
 description = "A Django plugin for pytest."
@@ -1649,4 +1683,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "56d6ac402357f38352d7a082fb447bca47584b1b9fadab42a98b589ad7acc7bf"
+content-hash = "b2a5cf86a846f259bde53a3ab448a8e5621822d0928c61dddea99578c4dda3f2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ pytest-django = "^4.11.1"
 ruff = "^0.15.7"
 mypy = "^1.19.1"
 django-stubs = "^6.0.1"
+pytest-asyncio = "^1.3.0"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
@@ -34,6 +35,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "api_gateway.settings"
+asyncio_mode = "auto"
 python_files = ["test_*.py", "*_test.py", "testing/python/*.py"]
 testpaths = ["apps/gateway/tests*"]
 


### PR DESCRIPTION
Closes #10 
- Add pytest-asyncio library to pyproject.toml
- Update poetry.lock
- Update the tests
- Fix signals async calls